### PR TITLE
Dockerfile for druid - fixes to get Druid to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,10 @@ RUN apt-get install -y software-properties-common
 RUN apt-add-repository -y ppa:webupd8team/java \
       && apt-get update
 
-# Oracle Java 8
+# Oracle Java 8, MySQL, Supervisor, Git
 RUN echo oracle-java-8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections \
       && apt-get install -y oracle-java8-installer \
-      && apt-get install -y oracle-java8-set-default
-
-# MySQL (Metadata store)
-RUN apt-get install -y mysql-server
-
-# Supervisor
-RUN apt-get install -y supervisor
+      && apt-get install -y oracle-java8-set-default mysql-server supervisor git
 
 # Maven
 RUN wget -q -O - http://archive.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz | tar -xzf - -C /usr/local \
@@ -27,9 +21,6 @@ RUN wget -q -O - http://www.us.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeep
       && cp /usr/local/zookeeper-3.4.6/conf/zoo_sample.cfg /usr/local/zookeeper-3.4.6/conf/zoo.cfg \
       && ln -s /usr/local/zookeeper-3.4.6 /usr/local/zookeeper
 
-# git
-RUN apt-get install -y git
-
 # Druid system user
 RUN adduser --system --group --no-create-home druid \
       && mkdir -p /var/lib/druid \
@@ -39,51 +30,46 @@ RUN adduser --system --group --no-create-home druid \
 RUN mvn dependency:get -Dartifact=io.druid:druid-services:0.7.1.1
 
 # Druid (release tarball)
-#ENV DRUID_VERSION 0.7.1.1
-#RUN wget -q -O - http://static.druid.io/artifacts/releases/druid-services-$DRUID_VERSION-bin.tar.gz | tar -xzf - -C /usr/local
-#RUN ln -s /usr/local/druid-services-$DRUID_VERSION /usr/local/druid
+#ENV master 0.7.1.1
+#RUN wget -q -O - http://static.druid.io/artifacts/releases/druid-services-master-bin.tar.gz | tar -xzf - -C /usr/local
+#RUN ln -s /usr/local/druid-services-master /usr/local/druid
 
 # Druid (from source)
 RUN mkdir -p /usr/local/druid/lib /usr/local/druid/repository
-ENV DRUID_VERSION master
 # trigger rebuild only if branch changed
-ADD https://api.github.com/repos/metamx/druid/git/refs/heads/$DRUID_VERSION druid-version.json
-RUN git clone -q --branch $DRUID_VERSION --depth 1 https://github.com/metamx/druid.git /tmp/druid
+ADD https://api.github.com/repos/metamx/druid/git/refs/heads/master druid-version.json
+RUN git clone -q --branch master --depth 1 https://github.com/metamx/druid.git /tmp/druid
 WORKDIR /tmp/druid
 # package and install Druid locally
-RUN mvn -U -B versions:set -DnewVersion=$DRUID_VERSION \
-  && mvn -U -B clean install -DskipTests=true -Dmaven.javadoc.skip=true \
-  && cp services/target/druid-services-$DRUID_VERSION-selfcontained.jar /usr/local/druid/lib
+RUN mvn -U -B clean install -DskipTests=true -Dmaven.javadoc.skip=true \
+  && cp services/target/druid-services-0.7.2-SNAPSHOT-selfcontained.jar /usr/local/druid/lib
 
 # pull dependencies for Druid extensions
-RUN java "-Ddruid.extensions.coordinates=[\"io.druid.extensions:druid-s3-extensions\",\"io.druid.extensions:mysql-metadata-storage\"]" \
-      -Ddruid.extensions.localRepository=/usr/local/druid/repository \
-      -Ddruid.extensions.remoteRepositories=[\"file:///root/.m2/repository/\",\"https://repo1.maven.org/maven2/\"] \
-      -cp /usr/local/druid/lib/* \
-      io.druid.cli.Main tools pull-deps
 
-WORKDIR /
+RUN /bin/bash -c 'java "-Ddruid.extensions.coordinates=[\"io.druid.extensions:druid-s3-extensions\",\"io.druid.extensions:mysql-metadata-storage\"]" -Ddruid.extensions.localRepository=/usr/local/druid/repository -Ddruid.extensions.remoteRepositories=[\"file:///root/.m2/repository/\",\"https://repo1.maven.org/maven2/\"] -cp /usr/local/druid/lib/* io.druid.cli.Main tools pull-deps'
 
-# Setup metadata store
-RUN /etc/init.d/mysql start && echo "GRANT ALL ON druid.* TO 'druid'@'localhost' IDENTIFIED BY 'diurd'; CREATE database druid CHARACTER SET utf8;" | mysql -u root && /etc/init.d/mysql stop
-
+#
+## Setup metadata store
+RUN /bin/bash -c "/etc/init.d/mysql start && mysql -e \"GRANT ALL ON druid.* TO 'druid'@'localhost' IDENTIFIED BY 'diurd'; CREATE database druid CHARACTER SET utf8;\" && /etc/init.d/mysql stop"
+#
 # Add sample data
-RUN /etc/init.d/mysql start && java -cp /usr/local/druid/lib/druid-services-*-selfcontained.jar -Ddruid.extensions.coordinates=[\"io.druid.extensions:mysql-metadata-storage\"] -Ddruid.metadata.storage.type=mysql io.druid.cli.Main tools metadata-init --connectURI="jdbc:mysql://localhost:3306/druid" --user=druid --password=diurd && /etc/init.d/mysql stop
-ADD sample-data.sql sample-data.sql
-RUN /etc/init.d/mysql start && cat sample-data.sql | mysql -u root druid && /etc/init.d/mysql stop
+RUN /bin/bash -c '/etc/init.d/mysql start && java -cp /usr/local/druid/lib/druid-services-*-selfcontained.jar -Ddruid.extensions.coordinates=[\"io.druid.extensions:mysql-metadata-storage\"] -Ddruid.metadata.storage.type=mysql io.druid.cli.Main tools metadata-init --connectURI="jdbc:mysql://localhost:3306/druid" --user=druid --password=diurd && /etc/init.d/mysql stop'
 
-# Setup supervisord
+ADD sample-data.sql /tmp/sample-data.sql
+RUN /etc/init.d/mysql start && cat /tmp/sample-data.sql | mysql -u root druid && /etc/init.d/mysql stop
+
+## Setup supervisord
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
-# Clean up
+## Clean up
 RUN apt-get clean && rm -rf /tmp/* /var/tmp/*
 
-# Expose ports:
-# - 8081: HTTP (coordinator)
-# - 8082: HTTP (broker)
-# - 8083: HTTP (historical)
-# - 3306: MySQL
-# - 2181 2888 3888: ZooKeeper
+## Expose ports:
+## - 8081: HTTP (coordinator)
+## - 8082: HTTP (broker)
+## - 8083: HTTP (historical)
+## - 3306: MySQL
+## - 2181 2888 3888: ZooKeeper
 EXPOSE 8081
 EXPOSE 8082
 EXPOSE 8083
@@ -91,4 +77,4 @@ EXPOSE 3306
 EXPOSE 2181 2888 3888
 
 WORKDIR /var/lib/druid
-ENTRYPOINT export HOSTIP="$(resolveip -s $HOSTNAME)" && exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+#ENTRYPOINT export HOSTIP="$(resolveip -s $HOSTNAME)" && exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN mvn -U -B clean install -DskipTests=true -Dmaven.javadoc.skip=true \
 
 # pull dependencies for Druid extensions
 
-RUN /bin/bash -c 'java "-Ddruid.extensions.coordinates=[\"io.druid.extensions:druid-s3-extensions\",\"io.druid.extensions:mysql-metadata-storage\"]" -Ddruid.extensions.localRepository=/usr/local/druid/repository -Ddruid.extensions.remoteRepositories=[\"file:///root/.m2/repository/\",\"https://repo1.maven.org/maven2/\"] -cp /usr/local/druid/lib/* io.druid.cli.Main tools pull-deps'
+RUN /bin/bash -c 'java "-Ddruid.extensions.coordinates=[\"io.druid.extensions:druid-s3-extensions\",\"io.druid.extensions:mysql-metadata-storage\", \"io.druid.extensions:druid-kafka-eight\"]" -Ddruid.extensions.localRepository=/usr/local/druid/repository -Ddruid.extensions.remoteRepositories=[\"file:///root/.m2/repository/\",\"https://repo1.maven.org/maven2/\"] -cp /usr/local/druid/lib/* io.druid.cli.Main tools pull-deps'
 
 #
 ## Setup metadata store

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN adduser --system --group --no-create-home druid \
       && chown druid:druid /var/lib/druid
 
 # Pre-cache Druid dependencies (this step is optional, but can help speed up re-building the Docker image)
-RUN mvn dependency:get -Dartifact=io.druid:druid-services:0.7.1.1
+#RUN mvn dependency:get -Dartifact=io.druid:druid-services:0.7.1.1
 
 
 # Druid (from source)

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 ## Clean up
 RUN apt-get clean && rm -rf /tmp/* /var/tmp/*
-
+RUN chown -R druid:druid /usr/local/druid
 ## Expose ports:
 ## - 8081: HTTP (coordinator)
 ## - 8082: HTTP (broker)

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN git clone -q --branch master --depth 1 https://github.com/metamx/druid.git /
 WORKDIR /tmp/druid
 # package and install Druid locally
 RUN mvn -U -B clean install -DskipTests=true -Dmaven.javadoc.skip=true \
-  && cp services/target/druid-services-0.7.2-SNAPSHOT-selfcontained.jar /usr/local/druid/lib
+  && cp services/target/druid-services-0.8.0-SNAPSHOT-selfcontained.jar /usr/local/druid/lib
 
 # pull dependencies for Druid extensions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,4 +72,4 @@ EXPOSE 3306
 EXPOSE 2181 2888 3888
 
 WORKDIR /var/lib/druid
-ENTRYPOINT export HOSTIP="$(resolveip -s $HOSTNAME)" && exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+#ENTRYPOINT export HOSTIP="$(resolveip -s $HOSTNAME)" && exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-add-repository -y ppa:webupd8team/java \
 
 # Oracle Java 8, MySQL, Supervisor, Git
 RUN echo oracle-java-8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections \
-      && apt-get install -y oracle-java8-installer oracle-java8-set-default mysql-server supervisor git
+      && apt-get install -y oracle-java8-installer oracle-java8-set-default mysql-server supervisor git curl
 
 # Maven
 RUN wget -q -O - http://archive.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz | tar -xzf - -C /usr/local \
@@ -22,7 +22,7 @@ RUN wget -q -O - http://www.us.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeep
 
 # Druid system user
 RUN adduser --system --group --no-create-home druid \
-      && mkdir -p /var/lib/druid \
+      && mkdir -p /var/lib/druid/log \
       && chown druid:druid /var/lib/druid
 
 # Pre-cache Druid dependencies (this step is optional, but can help speed up re-building the Docker image)
@@ -72,4 +72,3 @@ EXPOSE 3306
 EXPOSE 2181 2888 3888
 
 WORKDIR /var/lib/druid
-#ENTRYPOINT export HOSTIP="$(resolveip -s $HOSTNAME)" && exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-add-repository -y ppa:webupd8team/java \
 
 # Oracle Java 8, MySQL, Supervisor, Git
 RUN echo oracle-java-8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections \
-      && apt-get install -y oracle-java8-installer -y oracle-java8-set-default mysql-server supervisor git
+      && apt-get install -y oracle-java8-installer oracle-java8-set-default mysql-server supervisor git
 
 # Maven
 RUN wget -q -O - http://archive.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz | tar -xzf - -C /usr/local \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ RUN apt-add-repository -y ppa:webupd8team/java \
 
 # Oracle Java 8, MySQL, Supervisor, Git
 RUN echo oracle-java-8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections \
-      && apt-get install -y oracle-java8-installer \
-      && apt-get install -y oracle-java8-set-default mysql-server supervisor git
+      && apt-get install -y oracle-java8-installer -y oracle-java8-set-default mysql-server supervisor git
 
 # Maven
 RUN wget -q -O - http://archive.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz | tar -xzf - -C /usr/local \
@@ -29,10 +28,6 @@ RUN adduser --system --group --no-create-home druid \
 # Pre-cache Druid dependencies (this step is optional, but can help speed up re-building the Docker image)
 RUN mvn dependency:get -Dartifact=io.druid:druid-services:0.7.1.1
 
-# Druid (release tarball)
-#ENV master 0.7.1.1
-#RUN wget -q -O - http://static.druid.io/artifacts/releases/druid-services-master-bin.tar.gz | tar -xzf - -C /usr/local
-#RUN ln -s /usr/local/druid-services-master /usr/local/druid
 
 # Druid (from source)
 RUN mkdir -p /usr/local/druid/lib /usr/local/druid/repository
@@ -77,4 +72,4 @@ EXPOSE 3306
 EXPOSE 2181 2888 3888
 
 WORKDIR /var/lib/druid
-#ENTRYPOINT export HOSTIP="$(resolveip -s $HOSTNAME)" && exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+ENTRYPOINT export HOSTIP="$(resolveip -s $HOSTNAME)" && exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/supervisor.peon
+++ b/supervisor.peon
@@ -1,0 +1,25 @@
+[supervisord]
+nodaemon=true
+loglevel=debug
+
+
+[program:druid-peon]
+user=root
+command=java
+  -server
+  -Xmx4g
+  -Duser.timezone=UTC
+  -Dfile.encoding=UTF-8
+  -Ddruid.host=172.17.0.36
+  -Ddruid.segmentCache.locations="[{\"path\":\"/var/tmp/druid/indexCache\",\"maxSize\":5000000000}]"
+  -Ddruid.zk.service.host=172.17.0.35
+  -Ddruid.extensions.coordinates=[\"io.druid.extensions:mysql-metadata-storage\"]
+  -Ddruid.extensions.localRepository=/usr/local/druid/repository
+  -Ddruid.metadata.storage.type=mysql
+  -Ddruid.metadata.storage.connector.connectURI=jdbc:mysql://172.17.42.1:3306/druid
+  -Ddruid.metadata.storage.connector.user=druid
+  -Ddruid.metadata.storage.connector.password=diurd
+  -Ddruid.processing.numThreads=2
+  -Ddruid.peon.mode=remote
+  -cp /usr/local/druid/lib/*
+  io.druid.cli.Main server historical 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -13,7 +13,7 @@ user=mysql
 priority=0
 
 [program:druid-coordinator]
-user=druid
+user=root
 command=java
   -server
   -Xmx2g
@@ -33,7 +33,7 @@ redirect_stderr=true
 priority=100
 
 [program:druid-indexing-service]
-user=druid
+user=root
 command=java
   -server
   -Xmx2g
@@ -48,15 +48,14 @@ command=java
   -Ddruid.metadata.storage.connector.password=diurd
   -Ddruid.indexer.storage.type=metadata
   -Ddruid.peon.mode=local
-  -Ddruid.processing.numThreads=2
+  -Ddruid.processing.numThreads=5
   -Ddruid.indexer.queue.startDelay=PT0M
-  -Ddruid.processing.numThreads=2
-  -Ddruid.indexer.runner.javaOpts="-server -Xmx4g"
+  -Ddruid.indexer.runner.javaOpts="-server -Xmx7g"
   -cp /usr/local/druid/lib/*
   io.druid.cli.Main server overlord
 
 [program:druid-historical]
-user=druid
+user=root
 command=java
   -server
   -Xmx2g
@@ -68,7 +67,7 @@ command=java
   -Ddruid.s3.accessKey=AKIAIMKECRUYKDQGR6YQ
   -Ddruid.s3.secretKey=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
   -Ddruid.computation.buffer.size=67108864
-  -Ddruid.processing.numThreads=2
+  -Ddruid.processing.numThreads=5
   -Ddruid.segmentCache.locations="[{\"path\":\"/var/tmp/druid/indexCache\",\"maxSize\":5000000000}]"
   -Ddruid.server.maxSize=5000000000
   -cp /usr/local/druid/lib/*
@@ -77,18 +76,17 @@ redirect_stderr=true
 priority=100
 
 [program:druid-broker]
-user=druid
+user=root
 command=java
   -server
   -Xmx2g
   -Duser.timezone=UTC
   -Dfile.encoding=UTF-8
   -Ddruid.host=%(ENV_HOSTIP)s
-  -Ddruid.processing.numThreads=2
+  -Ddruid.processing.numThreads=5
   -Ddruid.computation.buffer.size=67108864
   -Ddruid.broker.cache.sizeInBytes=33554432
   -cp /usr/local/druid/lib/*
   io.druid.cli.Main server broker
 redirect_stderr=true
 priority=100
-

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -16,7 +16,7 @@ priority=0
 user=druid
 command=java
   -server
-  -Xmx4g
+  -Xmx2g
   -Duser.timezone=UTC
   -Dfile.encoding=UTF-8
   -Ddruid.host=%(ENV_HOSTIP)s
@@ -36,7 +36,7 @@ priority=100
 user=druid
 command=java
   -server
-  -Xmx4g
+  -Xmx2g
   -Duser.timezone=UTC
   -Dfile.encoding=UTF-8
   -Ddruid.host=%(ENV_HOSTIP)s
@@ -59,7 +59,7 @@ command=java
 user=druid
 command=java
   -server
-  -Xmx4g
+  -Xmx2g
   -Duser.timezone=UTC
   -Dfile.encoding=UTF-8
   -Ddruid.host=%(ENV_HOSTIP)s
@@ -80,7 +80,7 @@ priority=100
 user=druid
 command=java
   -server
-  -Xmx4g
+  -Xmx2g
   -Duser.timezone=UTC
   -Dfile.encoding=UTF-8
   -Ddruid.host=%(ENV_HOSTIP)s

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,6 +1,6 @@
 [supervisord]
 nodaemon=true
-loglevel=debug
+loglevel=error
 
 [program:zookeeper]
 command=/usr/local/zookeeper/bin/zkServer.sh start-foreground
@@ -16,7 +16,7 @@ priority=0
 user=druid
 command=java
   -server
-  -Xmx1g
+  -Xmx4g
   -Duser.timezone=UTC
   -Dfile.encoding=UTF-8
   -Ddruid.host=%(ENV_HOSTIP)s
@@ -36,7 +36,7 @@ priority=100
 user=druid
 command=java
   -server
-  -Xmx256m
+  -Xmx4g
   -Duser.timezone=UTC
   -Dfile.encoding=UTF-8
   -Ddruid.host=%(ENV_HOSTIP)s
@@ -48,8 +48,9 @@ command=java
   -Ddruid.metadata.storage.connector.password=diurd
   -Ddruid.indexer.storage.type=metadata
   -Ddruid.peon.mode=local
+  -Ddruid.processing.numThreads=2
   -Ddruid.indexer.queue.startDelay=PT0M
-  -Ddruid.indexer.runner.javaOpts="-server -Xmx1g"
+  -Ddruid.indexer.runner.javaOpts="-server -Xmx4g"
   -cp /usr/local/druid/lib/*
   io.druid.cli.Main server overlord
 
@@ -57,7 +58,7 @@ command=java
 user=druid
 command=java
   -server
-  -Xmx1g
+  -Xmx4g
   -Duser.timezone=UTC
   -Dfile.encoding=UTF-8
   -Ddruid.host=%(ENV_HOSTIP)s
@@ -77,7 +78,7 @@ priority=100
 user=druid
 command=java
   -server
-  -Xmx1g
+  -Xmx4g
   -Duser.timezone=UTC
   -Dfile.encoding=UTF-8
   -Ddruid.host=%(ENV_HOSTIP)s
@@ -87,3 +88,4 @@ command=java
   io.druid.cli.Main server broker
 redirect_stderr=true
 priority=100
+


### PR DESCRIPTION
As issue #3 notes, the Dockerfile in this repo wasn't building; I've been trying to update it to fix any issues that were causing the build to error out. I'm now able to build and am going to move on to testing Druid now in our staging environment. Notes on my changes:

1) I've bundled all of the apt-get install statements together so it only needs to be run once;
2) I've wrapped the java commands that install dependencies and set up maven repositories inside of a /bin/bash -c command, as it makes escaping control characters much easier (my build was dying earlier here, as apparently escaping the \'s in that step wasn't working as exxpected)
3) I've changed the syntax of the mysql database creation command to be cleaner and not rely on |, and fixed another error I was getting re: mysql syntax;
4) Instead of setting a specific version to download as an ENV, I'm just fetching the master branch of metamx/druid from github.

Take a look and let me know if you have any thoughts or questions for me.

Cheers,

--afsheen