### PR TITLE
Fix the XX:MaxDirectMemorySize exception

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -29,9 +29,11 @@ command=java
   -Ddruid.metadata.storage.connector.password=diurd
   -Ddruid.coordinator.asOverlord.enabled=true
   -Ddruid.coordinator.asOverlord.overlordService=druid/overlord
+  -Ddruid.indexer.fork.property.druid.processing.numThreads=1
   -Ddruid.indexer.storage.type=metadata
   -Ddruid.indexer.queue.startDelay=PT0M
   -Ddruid.indexer.runner.javaOpts="-server -Xmx1g -XX:MaxDirectMemorySize=2147483648"
+  -Ddruid.processing.buffer.sizeBytes=536870912
   -Ddruid.coordinator.startDelay=PT5S
   -cp /usr/local/druid/lib/*
   io.druid.cli.Main server coordinator


### PR DESCRIPTION
Hi Guys,

I fixed the error by letting the forked peon process only index with a single thread to constraint the memory usage and therefore the XX:MaxDirectMemorySize error will be thrown. This might make indexing a bit slower since it only will use one thread, but since it is a single machine, performance will not be one of the goals I would guess.

Cheers, Fokko