### PR TITLE
Added troubleshooting section with the OOM problems under OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Download and launch the docker image
 
 ```sh
 docker pull druidio/example-cluster
-docker run --rm -i -p 3000:8082 -p 3001:8081 -p 3090:8090 druidio/example-cluster
+docker run --rm -i -p 3000:8082 -p 3001:8081 druidio/example-cluster
 ```
 
 Wait a minute or so for Druid to start up and download the sample.
@@ -51,11 +51,10 @@ docker build -t example-cluster docker-druid
 You might want to look into the logs when debugging the Druid processes. This can be done by logging into the container using `docker ps`:
 ```
 CONTAINER ID        IMAGE                     COMMAND                  CREATED             STATUS              PORTS                                                                                                                      NAMES
-9e73cbfc5612        druidio/example-cluster   "/bin/sh -c 'export H"   7 seconds ago       Up 6 seconds        2181/tcp, 2888/tcp, 3306/tcp, 3888/tcp, 8083/tcp, 0.0.0.0:3001->8081/tcp, 0.0.0.0:3000->8082/tcp, 0.0.0.0:3090->8090/tcp   sick_lamport
+9e73cbfc5612        druidio/example-cluster   "/bin/sh -c 'export H"   7 seconds ago       Up 6 seconds        2181/tcp, 2888/tcp, 3306/tcp, 3888/tcp, 8083/tcp, 0.0.0.0:3001->8081/tcp, 0.0.0.0:3000->8082/tcp    sick_lamport
 ```
 
-And attaching to the container using `docker exec -ti 9e73cbfc5612 bash` logs are written to 
-`/tmp/`:
+And attaching to the container using `docker exec -ti 9e73cbfc5612 bash` logs are written to `/tmp/`:
 
 ```
 root@d59a3d4a68c3:/tmp# ls -lah        
@@ -76,5 +75,20 @@ drwxr-xr-x 61 root   root   4.0K Jan 18 20:38 ..
 -rw-------  1 root   root   7.4K Jan 18 20:39 zookeeper-stdout---supervisor-6AFVOR.log
 ```
 
+## Troubleshooting
 
+This section will help you troubleshoot problems related to the Dockerized Druid.
 
+### Out-Of-Memory (OOM) when using OSX
+
+When using Docker on OSX, the Docker environment will be executed within the [HyperKit](https://github.com/docker/hyperkit) hypervisor, a lightweight visualization framework for running the Docker containers:
+```
+docker-druid foobar$ ps -ax | grep docker.hyperkit
+71175 ??         0:04.02 /Applications/Docker.app/Contents/MacOS/com.docker.hyperkit -A -m 2048M -c 4 -u -s ...
+```
+
+The allocated resources are limited by default to 2 cpu's and 2gb of memory. Although 2gb is sufficient in most application, the Druid container is rather heavyweight because of the Mysql, Zookeeper and the JVM's. When start spawning additional JVM's, for example an indexing job, this might cause issues:
+```
+2017-01-20T15:59:58,445 INFO [forking-task-runner-0-[index_transactions_2017-01-20T15:59:50.637Z]] io.druid.indexing.overlord.ForkingTaskRunner - Process exited with status[137] for task: index_transactions_2017-01-20T15:59:50.637Z
+```
+From the log we observe that the process receives an 137 (=128+9) SIGKILL signal. Because it hit the memory limit, the application is killed instantly. To avoid this you might want to give more resources to the Docker hypervisor under Docker > Preferences.


### PR DESCRIPTION
Hi Guys,

I had some problems with the HyperKit hypervisor and the Druid docker image. Because of all the JVM's it is quite memory hungry ;) When I'd spawn an indexing job, it got killed with no sensible reason in the logs. When I dug deeper, I found the problem in the indexing service logs which reported the 137 exit code.
This problem took quite some time to debug and it would be nice to add a troubleshooting section to the README.

Cheers, Fokko