### PR TITLE
Create and chown the druid temporary dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,9 @@ RUN apt-get purge --auto-remove -y git \
                 /var/lib/apt/lists \
                 /usr/local/apache-maven-3.2.5 \
                 /usr/local/apache-maven \
-                /root/.m2
+                /root/.m2 \
+      && mkdir -p /tmp/druid/localStorage/ \
+      && chown druid:druid /tmp/druid/localStorage/
 
 WORKDIR /
 


### PR DESCRIPTION
Hi guys,

Druid requires a temporary dir for writing the segments. This path is not created by default:
```
java.io.IOException: Mkdirs failed to create file:/tmp/druid/localStorage/wikiticker/2015-09-12T00:00:00.000Z_2015-09-13T00:00:00.000Z/2017-02-27T15:36:48.883Z/0
	at org.apache.hadoop.fs.ChecksumFileSystem.create(ChecksumFileSystem.java:438) ~[hadoop-common-2.3.0.jar:?]
	at org.apache.hadoop.fs.ChecksumFileSystem.create(ChecksumFileSystem.java:424) ~[hadoop-common-2.3.0.jar:?]
	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:907) ~[hadoop-common-2.3.0.jar:?]
	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:868) ~[hadoop-common-2.3.0.jar:?]
	at io.druid.indexer.JobHelper$4.push(JobHelper.java:394) [druid-services-0.9.2-selfcontained.jar:0.9.2]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_121]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_121]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_121]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_121]
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:186) [hadoop-common-2.3.0.jar:?]
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:102) [hadoop-common-2.3.0.jar:?]
	at com.sun.proxy.$Proxy196.push(Unknown Source) [?:?]
	at io.druid.indexer.JobHelper.serializeOutIndex(JobHelper.java:412) [druid-services-0.9.2-selfcontained.jar:0.9.2]
	at io.druid.indexer.IndexGeneratorJob$IndexGeneratorReducer.reduce(IndexGeneratorJob.java:727) [druid-services-0.9.2-selfcontained.jar:0.9.2]
	at io.druid.indexer.IndexGeneratorJob$IndexGeneratorReducer.reduce(IndexGeneratorJob.java:478) [druid-services-0.9.2-selfcontained.jar:0.9.2]
	at org.apache.hadoop.mapreduce.Reducer.run(Reducer.java:171) [hadoop-mapreduce-client-core-2.3.0.jar:?]
	at org.apache.hadoop.mapred.ReduceTask.runNewReducer(ReduceTask.java:627) [hadoop-mapreduce-client-core-2.3.0.jar:?]
	at org.apache.hadoop.mapred.ReduceTask.run(ReduceTask.java:389) [hadoop-mapreduce-client-core-2.3.0.jar:?]
	at org.apache.hadoop.mapred.LocalJobRunner$Job$ReduceTaskRunnable.run(LocalJobRunner.java:319) [hadoop-mapreduce-client-common-2.3.0.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_121]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_121]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_121]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_121]
	at java.lang.Thread.run(Thread.java:745) [?:1.8.0_121]
```

Cheers,
Fokko