### PR TITLE
Merge the Coordinator and Overlord

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:14.04
 
 # Java 8
-RUN apt-get install -y software-properties-common \
+RUN apt-get update -y \
+      && apt-get install -y software-properties-common \
       && apt-add-repository -y ppa:webupd8team/java \
       && apt-get purge --auto-remove -y software-properties-common \
       && apt-get update \
@@ -34,15 +35,12 @@ RUN adduser --system --group --no-create-home druid \
       && mkdir -p /var/lib/druid \
       && chown druid:druid /var/lib/druid
 
-# Druid (release tarball)
-#ENV DRUID_VERSION 0.7.1.1
-#RUN wget -q -O - http://static.druid.io/artifacts/releases/druid-services-$DRUID_VERSION-bin.tar.gz | tar -xzf - -C /usr/local
-#RUN ln -s /usr/local/druid-services-$DRUID_VERSION /usr/local/druid
-
 # Druid (from source)
 RUN mkdir -p /usr/local/druid/lib
+
 # whichever github owner (user or org name) you would like to build from
 ENV GITHUB_OWNER druid-io
+
 # whichever branch you would like to build
 ENV DRUID_VERSION master
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -27,32 +27,16 @@ command=java
   -Ddruid.metadata.storage.connector.connectURI=jdbc:mysql://localhost:3306/druid
   -Ddruid.metadata.storage.connector.user=druid
   -Ddruid.metadata.storage.connector.password=diurd
+  -Ddruid.coordinator.asOverlord.enabled=true
+  -Ddruid.coordinator.asOverlord.overlordService=druid/overlord
+  -Ddruid.indexer.storage.type=metadata
+  -Ddruid.indexer.queue.startDelay=PT0M
+  -Ddruid.indexer.runner.javaOpts="-server -Xmx1g -XX:MaxDirectMemorySize=2147483648"
   -Ddruid.coordinator.startDelay=PT5S
   -cp /usr/local/druid/lib/*
   io.druid.cli.Main server coordinator
 redirect_stderr=true
 priority=100
-
-[program:druid-indexing-service]
-user=druid
-command=java
-  -server
-  -Xmx256m
-  -Duser.timezone=UTC
-  -Dfile.encoding=UTF-8
-  -Ddruid.host=%(ENV_HOSTIP)s
-  -Ddruid.extensions.loadList=[\"mysql-metadata-storage\"]
-  -Ddruid.extensions.directory=/usr/local/druid/extensions
-  -Ddruid.extensions.hadoopDependenciesDir=/usr/local/druid/hadoop/hadoop_druid_dependencies
-  -Ddruid.metadata.storage.type=mysql
-  -Ddruid.metadata.storage.connector.connectURI=jdbc:mysql://localhost:3306/druid
-  -Ddruid.metadata.storage.connector.user=druid
-  -Ddruid.metadata.storage.connector.password=diurd
-  -Ddruid.indexer.storage.type=metadata
-  -Ddruid.indexer.queue.startDelay=PT0M
-  -Ddruid.indexer.runner.javaOpts="-server -Xmx1g -XX:MaxDirectMemorySize=2147483648"
-  -cp /usr/local/druid/lib/*
-  io.druid.cli.Main server overlord
 
 [program:druid-historical]
 user=druid


### PR DESCRIPTION
Hi Guys,

Since 0.10.0 it is possible to combine the overlord and coordinator. For the Docker image it is nice to have these combined so we can omit one of the jvm's. This will reduce the memory footprint required by the image.

Cheers, Fokko