### PR TITLE
Build master branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 
 # Set version and github repo which you want to build from
 ENV GITHUB_OWNER druid-io
-ENV DRUID_VERSION 0.9.2
+ENV DRUID_VERSION master
 ENV ZOOKEEPER_VERSION 3.4.9
 
 # Java 8


### PR DESCRIPTION
As pointed out in @gianm's reviewing process 👍 

Because of an old PR, the version was set hard at 0.9.2, but I prefer to build the master branch as it was before. This gives us the latest functionality and also the ability to easily try out the latest features.

Cheers, Fokko